### PR TITLE
Fix invalidId ErrorResponse parameter type and usage

### DIFF
--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -8,7 +8,7 @@ export const usersController = {
     async getUserById(request: Request, response: Response) {
         const userId = Number(request.params.userId);
         if (isNaN(userId)) {
-            const errorResponse = ErrorResponse.invalidId(request.params.userId);
+            const errorResponse = ErrorResponse.invalidId(userId);
             response.status(400).json(errorResponse);
             return;
         }
@@ -31,7 +31,7 @@ export const usersController = {
         }
         const userId = Number(request.params.userId);
         if (isNaN(userId)) {
-            const errorResponse = ErrorResponse.invalidId(request.params.userId);
+            const errorResponse = ErrorResponse.invalidId(userId);
             response.status(400).json(errorResponse);
             return;
         }

--- a/src/models/ErrorResponse.ts
+++ b/src/models/ErrorResponse.ts
@@ -38,7 +38,7 @@ export class ErrorResponse implements ErrorResponseInterface {
         return new ErrorResponse(`Nutzername "${username}" bereits vergeben`, 409);
     }
 
-    static invalidId(id: any): ErrorResponse {
+    static invalidId(id: number): ErrorResponse {
         return new ErrorResponse(`Ungültige ID "${id}"`, 400);
     }
 


### PR DESCRIPTION
Update the `invalidId` method to specify the parameter type as number